### PR TITLE
Support specifying multiple listeners in the same penguin process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.16"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
+checksum = "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.16"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
+checksum = "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
 dependencies = [
  "anstream",
  "anstyle",

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -179,15 +179,22 @@ pub struct ClientArgs {
 }
 
 /// Penguin server arguments.
+/// TODO: validation of `host` and `port`: must be at least one
 #[derive(Args, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ServerArgs {
     /// Defines the HTTP listening host - the network interface.
-    #[arg(long, default_value = "::")]
-    pub host: String,
+    /// If multiple ports are specified, `penguin` will listen on all of them.
+    /// If TLS is enabled, it will apply to all listening hosts.
+    #[arg(long, default_values = ["::"], required = true)]
+    pub host: Vec<String>,
     /// Defines the HTTP listening port.
-    #[arg(short, long, default_value_t = 8080)]
-    pub port: u16,
+    /// If the number of ports is less than the number of hosts,
+    /// the last port will be used for the remaining hosts. If the number of
+    /// ports is greater than the number of hosts, the remaining ports will
+    /// be ignored.
+    #[arg(short, long, default_values_t = [8080], required = true)]
+    pub port: Vec<u16>,
     /// Specifies another HTTP server to proxy requests to when
     /// penguin receives a normal HTTP request. Useful for hiding penguin in
     /// plain sight.

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -179,7 +179,6 @@ pub struct ClientArgs {
 }
 
 /// Penguin server arguments.
-/// TODO: validation of `host` and `port`: must be at least one
 #[derive(Args, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ServerArgs {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -120,7 +120,7 @@ pub struct ClientArgs {
     #[arg(long, default_value_t = 25)]
     pub keepalive: u64,
     /// Maximum number of times to retry before exiting.
-    /// Defaults 0, meaning unlimited.
+    /// A value of 0 means unlimited.
     #[arg(long, default_value_t = 0)]
     pub max_retry_count: u32,
     /// Maximum wait time (in milliseconds) before retrying after a
@@ -182,11 +182,10 @@ pub struct ClientArgs {
 #[derive(Args, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ServerArgs {
-    /// Defines the HTTP listening host - the network interface
-    /// (defaults to ::).
+    /// Defines the HTTP listening host - the network interface.
     #[arg(long, default_value = "::")]
     pub host: String,
-    /// Defines the HTTP listening port (defaults to port 8080).
+    /// Defines the HTTP listening port.
     #[arg(short, long, default_value_t = 8080)]
     pub port: u16,
     /// Specifies another HTTP server to proxy requests to when
@@ -200,7 +199,7 @@ pub struct ServerArgs {
     /// and TLS.
     #[arg(long)]
     pub obfs: bool,
-    /// Content to send with a 404 response. Defaults to 'Not found'.
+    /// Content to send with a 404 response.
     #[arg(long = "404-resp", default_value = "Not found")]
     pub not_found_resp: String,
     /// An optional Pre-Shared Key for WebSocket upgrade. If this

--- a/src/client/handle_remote/mod.rs
+++ b/src/client/handle_remote/mod.rs
@@ -99,8 +99,8 @@ impl Stdio {
 impl AsyncRead for Stdio {
     fn poll_read(
         mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context,
-        buf: &mut tokio::io::ReadBuf,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
         std::pin::Pin::new(&mut self.stdin).poll_read(cx, buf)
     }
@@ -109,7 +109,7 @@ impl AsyncRead for Stdio {
 impl AsyncWrite for Stdio {
     fn poll_write(
         mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context,
+        cx: &mut std::task::Context<'_>,
         buf: &[u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
         std::pin::Pin::new(&mut self.stdout).poll_write(cx, buf)
@@ -117,14 +117,14 @@ impl AsyncWrite for Stdio {
 
     fn poll_flush(
         mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
         std::pin::Pin::new(&mut self.stdout).poll_flush(cx)
     }
 
     fn poll_shutdown(
         mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
         std::pin::Pin::new(&mut self.stdout).poll_shutdown(cx)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -129,7 +129,13 @@ pub async fn server_main(args: &'static ServerArgs) -> Result<(), Error> {
             });
         }
     }
-    todo!()
+    while let Some(res) = listening_tasks.join_next().await {
+        if let Err(err) = res {
+            assert!(!err.is_panic(), "Panic in a listener: {err}");
+            error!("Listener finished with error: {err}");
+        }
+    }
+    Ok(())
 }
 
 /// Create a list of `SocketAddr`s from the command-line arguments on which to listen.

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,8 +30,8 @@ fn test_setup_log() {
 
 fn make_server_args(host: &str, port: u16) -> arg::ServerArgs {
     arg::ServerArgs {
-        host: host.to_string(),
-        port,
+        host: vec![host.to_string()],
+        port: vec![port],
         backend: None,
         obfs: false,
         not_found_resp: "404".to_string(),


### PR DESCRIPTION
Easy now thanks to hyper 1

TODO:
- [x] Add corresponding tests