### PR TITLE
Reorganize tls root CA features

### DIFF
--- a/.config/mutants.toml
+++ b/.config/mutants.toml
@@ -17,7 +17,8 @@ features = [
     "tests-real-internet4",
     "default-is-ipv6",
     "ring",
-    "rustls-native-roots",
+    "tls-rustls",
+    "system-roots",
 ]
 test_tool = "cargo"
 profile = "dev"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,9 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         tls:
-        - nativetls
-        - rustls-native-roots
-        - rustls-webpki-roots
+        - tls-native
+        - tls-rustls
     permissions:
       contents: read
       security-events: write
@@ -43,7 +42,7 @@ jobs:
         run:
           cargo clippy
           --no-default-features
-          --features ${{ matrix.tls }},ring,tests-real-internet4,tests-real-internet6,tokio-console,deadlock-detection,penguin-binary,acme,tungstenite
+          --features ${{ matrix.tls }},system-roots,webpki-roots,aws-lc-rs,tests-real-internet4,tests-real-internet6,tokio-console,deadlock-detection,penguin-binary,acme,tungstenite
           --message-format=json
           --
           -D warnings --verbose | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt

--- a/.github/workflows/full-test.sh
+++ b/.github/workflows/full-test.sh
@@ -3,7 +3,6 @@
 TLS=$1
 CONFIG_NAME=$2
 VERBOSE=${3:---verbose}
-export RUSTFLAGS="-Cinstrument-coverage"
 
 # Run async-acceptor tests only
 cargo nextest run --all-targets "$VERBOSE" --package async-acceptor
@@ -32,27 +31,34 @@ cargo nextest run --all-targets "$VERBOSE" --no-default-features --package pengu
 
 
 
-# Run cargo tests with more features on
-cargo nextest run --all-targets "$VERBOSE" --features "$TLS",ring,tests-real-internet4,tests-acme-has-pebble,penguin-binary,acme,default-is-ipv6,tokio-console,deadlock-detection --no-default-features
+# Run cargo tests with more features on, permuting through TLS CA and rustls configurations
+for backend in ring aws-lc-rs; do
+  for root in "" system-roots webpki-roots "system-roots,webpki-roots"; do
+    cargo nextest run --all-targets "$VERBOSE" --features "$TLS",$root,$backend,tests-real-internet4,tests-acme-has-pebble,penguin-binary,acme,default-is-ipv6,tokio-console,deadlock-detection --no-default-features
+  done
+done
 
 # Run cargo tests with default features
 case "$CONFIG_NAME" in
   *linux-gnu)
     printf '[target.%s]\nrunner="sudo -E"' "$(rustc -vV | sed -n 's,host: ,,p')" > ~/.cargo/config.toml
     cargo nextest run --all-targets "$VERBOSE" --features "$TLS",ring,tests-real-internet4,acme,penguin-binary,tproxy --no-default-features
+    cargo nextest run --all-targets "$VERBOSE" --features "$TLS",aws-lc-rs,tests-real-internet4,acme,penguin-binary,tproxy --no-default-features
     rm ~/.cargo/config.toml
     ;;
   *)
     cargo nextest run --all-targets "$VERBOSE" --features "$TLS",ring,tests-real-internet4,acme,penguin-binary,tproxy --no-default-features
+    cargo nextest run --all-targets "$VERBOSE" --features "$TLS",aws-lc-rs,tests-real-internet4,acme,penguin-binary,tproxy --no-default-features
     ;;
 esac
 
 # Run cargo tests with the nohash hashmap
 cargo nextest run --all-targets "$VERBOSE" --features "$TLS",ring,tests-real-internet4,acme,penguin-binary,nohash --no-default-features
+cargo nextest run --all-targets "$VERBOSE" --features "$TLS",aws-lc-rs,tests-real-internet4,acme,penguin-binary,nohash --no-default-features
 
 # Run cargo tests with PENGUIN_TLS_CHROMIUM_LIKE enabled
-if [ "$TLS" != "nativetls" ]; then
-  PENGUIN_TLS_CHROMIUM_LIKE=on cargo nextest run --all-targets "$VERBOSE" --features "$TLS",ring,tests-real-internet4,acme,penguin-binary --no-default-features
+if [ "$TLS" == "tls-rustls" ]; then
+  PENGUIN_TLS_CHROMIUM_LIKE=on cargo nextest run --all-targets "$VERBOSE" --features "$TLS",aws-lc-rs,tests-real-internet4,acme,penguin-binary --no-default-features
 fi
 
 

--- a/.github/workflows/full-test.sh
+++ b/.github/workflows/full-test.sh
@@ -33,7 +33,7 @@ cargo nextest run --all-targets "$VERBOSE" --no-default-features --package pengu
 
 # Run cargo tests with more features on, permuting through TLS CA and rustls configurations
 for backend in ring aws-lc-rs; do
-  for root in "" system-roots webpki-roots "system-roots,webpki-roots"; do
+  for root in "" system-roots webpki-roots dn42-roots "system-roots,webpki-roots" "webpki-roots,dn42-roots" "system-roots,webpki-roots,dn42-roots"; do
     cargo nextest run --all-targets "$VERBOSE" --features "$TLS",$root,$backend,tests-real-internet4,tests-acme-has-pebble,penguin-binary,acme,default-is-ipv6,tokio-console,deadlock-detection --no-default-features
   done
 done

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -21,9 +21,8 @@ jobs:
         - name: Windows
           os: windows-latest
         tls:
-        - nativetls
-        - rustls-native-roots
-        - rustls-webpki-roots
+        - tls-native
+        - tls-rustls
 
     steps:
     - uses: actions/checkout@v7
@@ -58,36 +57,36 @@ jobs:
 
     - name: Check default features
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,penguin-binary,acme,tungstenite,tproxy --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,penguin-binary,acme,tungstenite,tproxy --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,penguin-binary,acme,tungstenite,tproxy --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,penguin-binary,acme,tungstenite,tproxy --no-default-features -- --help
 
     - name: Check server only
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,server --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,server --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,server --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,server --no-default-features -- --help
 
     - name: Check client only
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,client --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,client --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,client --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,client --no-default-features -- --help
 
     - name: Check client with tproxy and http-proxy
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,client,tproxy,http-proxy --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-udp,client,tproxy,http-proxy --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,client,tproxy,http-proxy --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,aws-lc-rs,tests-real-internet4,tests-udp,client,tproxy,http-proxy --no-default-features -- --help
 
     - name: Check with most features on, using ring
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},ring,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,webpki-roots,ring,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,webpki-roots,ring,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features -- --help
 
     - name: Check with most features on, using aws-lc-rs
       run: |
-        cargo check --verbose --features ${{ matrix.tls }},aws-lc-rs,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features
-        cargo run --verbose --features ${{ matrix.tls }},aws-lc-rs,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features -- --help
+        cargo check --verbose --features ${{ matrix.tls }},system-roots,webpki-roots,aws-lc-rs,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features
+        cargo run --verbose --features ${{ matrix.tls }},system-roots,webpki-roots,aws-lc-rs,tests-real-internet4,tests-real-internet6,default-is-ipv6,tests-acme-has-pebble,penguin-binary,acme,remove-logging,deadlock-detection,nohash,tproxy,http-proxy --no-default-features -- --help
 
-    - name: Check with most features on (nativetls without any rustls)
-      if: matrix.tls == 'nativetls'
+    - name: Check with most features on (tls-native without any rustls)
+      if: matrix.tls == 'tls-native'
       run: |
         cargo check --verbose --features ${{ matrix.tls }},tests-real-internet4,tests-real-internet6,default-is-ipv6,penguin-binary,remove-logging,deadlock-detection,nohash,tproxy --no-default-features
         cargo run --verbose --features ${{ matrix.tls }},tests-real-internet4,tests-real-internet6,penguin-binary,remove-logging,deadlock-detection,nohash,tproxy --no-default-features -- --help

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -30,9 +30,8 @@ jobs:
           os: windows-11-arm
           codecov_os_name: windows
         tls:
-        - nativetls
-        - rustls-native-roots
-        - rustls-webpki-roots
+        - tls-native
+        - tls-rustls
 
     steps:
     - uses: actions/checkout@v7
@@ -61,7 +60,9 @@ jobs:
       run: .github/workflows/pebble.sh
 
     - name: Run cargo tests
-      run: .github/workflows/test-coverage.sh ${{ matrix.tls }} ${{ matrix.config.name }}
+      run: .github/workflows/full-test.sh ${{ matrix.tls }} ${{ matrix.config.name }}
+      env:
+        RUSTFLAGS: -Cinstrument-coverage
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -61,6 +61,7 @@ jobs:
 
     - name: Run cargo tests
       run: .github/workflows/full-test.sh ${{ matrix.tls }} ${{ matrix.config.name }}
+      shell: bash
       env:
         RUSTFLAGS: -Cinstrument-coverage
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dn42-root-ca"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51984ad3a3652471455fa382b213034a17830af47b25ef72eaf95b0832b9dda3"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2140,7 @@ dependencies = [
  "derive_more",
  "dhat",
  "divan",
+ "dn42-root-ca",
  "futures-util",
  "http",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,6 @@ dependencies = [
  "console-subscriber",
  "derive_more",
  "dhat",
- "divan",
  "dn42-root-ca",
  "futures-util",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -130,7 +130,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -142,7 +142,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -156,13 +156,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -179,9 +179,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -261,15 +261,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bit-vec"
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -345,9 +345,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -553,18 +553,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -630,7 +630,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -679,7 +679,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -704,7 +704,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -724,9 +724,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -816,9 +816,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -847,9 +847,9 @@ checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -870,7 +870,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -942,25 +942,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
 ]
 
@@ -1000,14 +988,14 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "flate2",
- "nom 7.1.3",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -1029,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1354,7 +1342,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1373,16 +1361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1405,9 +1393,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1469,9 +1457,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1503,9 +1491,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1565,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1649,7 +1637,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1776,7 +1764,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1823,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1850,7 +1838,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1864,18 +1852,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1885,9 +1867,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1956,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1993,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2075,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -2123,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-penguin"
@@ -2133,7 +2115,7 @@ version = "0.8.4"
 dependencies = [
  "arc-swap",
  "async-acceptor",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "clap",
  "console-subscriber",
@@ -2236,9 +2218,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2246,29 +2228,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2279,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2326,15 +2308,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2397,9 +2379,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2431,7 +2413,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2485,18 +2467,18 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2514,9 +2496,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2552,13 +2534,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2583,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2606,13 +2588,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2707,7 +2690,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2876,15 +2859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,7 +2900,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2951,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3074,12 +3048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,8 +3100,8 @@ dependencies = [
  "log",
  "nom 8.0.0",
  "pin-project",
- "rand 0.8.6",
- "sha1 0.10.6",
+ "rand 0.8.7",
+ "sha1 0.10.7",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -3164,28 +3132,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3205,7 +3173,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3245,11 +3213,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ pre-build = ["apt-get update && apt-get -y install nasm"]
 
 [workspace.metadata.cross.target.x86_64-unknown-linux-gnu]
 pre-build = ["apt-get update && apt-get -y install gcc-10 && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100"]
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dhat)', 'cfg(fuzzing)', 'cfg(loom)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,22 @@ resolver = "3"
 members = ["penguin-mux", "penguin", "async-acceptor", "penguin-socks", "cow-bytes"]
 exclude = ["fuzz"]
 
+[workspace.dependencies]
+bytes = { version = "^1, >=1.11.1", default-features = false }
+derive_more = { version = "2", default-features = false }
+futures-util = { version = "0.3", default-features = false }
+http-body-util = "0.1"
+hyper = "1"
+hyper-util = "0.1"
+nohash-hasher = { version = "0.2", default-features = false }
+parking_lot = "0.12"
+rand = { version = "0.10", default-features = false }
+thiserror = { version = "2", default-features = false }
+tokio = "^1, >=1.23.1"
+tokio-tungstenite = { version = "0.30", default-features = false }
+tracing = { version = "0.1", features = ["attributes"], default-features = false }
+tracing-subscriber = "^0.3, >=0.3.20"
+
 [profile.release]
 strip = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -111,13 +111,16 @@ Executable features:
 - `tls-rustls` (default): use `rustls`
 - `system-roots` (default): use `rustls` with system CA. Has no effect if `tls-native` is enabled.
 - `webpki-roots`: use `rustls` with bundled webpki CA. Has no effect if `tls-native` is enabled.
+- `dn42-roots`: use `rustls` with the dn42 root CA. Has no effect if `nativetls` is enabled.
+  You likely would want to enable at least one of the other root CA features as well,
+  otherwise the resulting client would only accept dn42 domains.
 - `ring`: use `ring` as the crypto provider for `rustls`. Has no effect if `tls-native` is enabled.
 - `aws-lc-rs` (default): use `aws-lc-rs` as the crypto provider for `rustls`. Has no effect if `tls-native` is enabled.
 
 It is fine to enable both `system-roots` and `webpki-roots`, in which case the certificates
 from both sources will be merged (whatever doing so might be useful for).
 If neither `system-roots` nor `webpki-roots` is enabled, no root certificates will be available
-and the user would have to provide their own CA roots via the `--tls-ca` command line option.
+and the user would have to provide their own root CA bundle via the `--tls-ca` command line option.
 
 - `default-is-ipv6`: use `::`/`::1` instead of `0.0.0.0`/`127.0.0.1` when an IP address is omitted in the client command line
 

--- a/README.md
+++ b/README.md
@@ -100,35 +100,41 @@ If both peers use this penguin implementation or any other implementation
 that generates `flow_id`s with a random number generator, this is safe.
 
 Library features:
-- `tungstenite`: implement our traits on `tokio_tungstenite::WebSocketStream` (default)
+- `tungstenite` (default): implement our traits on `tokio_tungstenite::WebSocketStream`
 
 Executable features:
-- `client`: build the client (default)
-- `server`: build the server (default)
-- `penguin-binary`: shorthand for both `server` and `client` (default)
+- `client` (default): build the client
+- `server` (default): build the server
+- `penguin-binary` (default): shorthand for both `server` and `client`
 
-- `rustls-native-roots`: use `rustls` with system CA (default)
-- `rustls-webpki-roots`: use `rustls` with bundled webpki CA
-- `nativetls`: use `native-tls`
-- `ring`: use `ring` as the crypto provider for `rustls`
-- `aws-lc-rs`: use `aws-lc-rs` as the crypto provider for `rustls`
+- `tls-native`: use `native-tls`
+- `tls-rustls` (default): use `rustls`
+- `system-roots` (default): use `rustls` with system CA. Has no effect if `tls-native` is enabled.
+- `webpki-roots`: use `rustls` with bundled webpki CA. Has no effect if `tls-native` is enabled.
+- `ring`: use `ring` as the crypto provider for `rustls`. Has no effect if `tls-native` is enabled.
+- `aws-lc-rs` (default): use `aws-lc-rs` as the crypto provider for `rustls`. Has no effect if `tls-native` is enabled.
+
+It is fine to enable both `system-roots` and `webpki-roots`, in which case the certificates
+from both sources will be merged (whatever doing so might be useful for).
+If neither `system-roots` nor `webpki-roots` is enabled, no root certificates will be available
+and the user would have to provide their own CA roots via the `--tls-ca` command line option.
 
 - `default-is-ipv6`: use `::`/`::1` instead of `0.0.0.0`/`127.0.0.1` when an IP address is omitted in the client command line
 
 - `tokio-console`: enable `console-subscriber` support
 - `remove-logging`: statically remove `trace` level logging and tracing code
 - `deadlock-detection`: spawn a background thread running `parking_lot`'s deadlock detection
-- `acme`: (requires `server`) enable the built-in ACME client (default)
-Will also make the binary use `rustls` even if `nativetls` is enabled due to internal dependencies.
-- `tproxy`: enable `:tproxy` (transparent proxy) remote types in the client (default)
-- `http-proxy`: enable `:http` (http proxy) remote types in the client (default)
+- `acme` (default): (requires `server`) enable the built-in ACME client
+Will also make the binary use `rustls` even if `tls-native` is enabled due to internal dependencies.
+- `tproxy` (default): enable `:tproxy` (transparent proxy) remote types in the client
+- `http-proxy` (default): enable `:http` (http proxy) remote types in the client
 
 Testing features:
 - `tests-real-internet4`: run tests that require IPv4 access to the internet
 - `tests-real-internet6`: run tests that require IPv4 access to the internet
 - `tests-udp`: run tests that expect UDP traffic to work reliably. They may be flaky depending on the network environment.
 - `tests-acme-has-pebble`: test the ACME client with a local ACME server at `https://localhost:14000/dir`
-- Note that when testing with `nativetls`, it is still necessary to enable one of `rcgen/ring` or `rcgen/aws_lc_rs`.
+- Note that when testing with `tls-native`, it is still necessary to enable one of `rcgen/ring` or `rcgen/aws_lc_rs`.
 
 ## Contribution
 All contributions are welcome. Please make sure you

--- a/async-acceptor/Cargo.toml
+++ b/async-acceptor/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["async", "listener", "tokio"]
 categories = ["asynchronous"]
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false }
-tokio = "^1, >=1.23.1"
+futures-util = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 async-acceptor = { path = ".", features = ["__dev-dependencies"] }

--- a/cow-bytes/Cargo.toml
+++ b/cow-bytes/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR GPL-3.0-or-later"
 keywords = ["buffers", "zero-copy", "io"]
 categories = ["network-programming", "data-structures", "no-std"]
 
-
 [dependencies]
-bytes = { version = "^1, >=1.11.1", default-features = false }
-derive_more = { version = "2", default-features = false, features = ["from", "is_variant"] }
+bytes = { workspace = true }
+derive_more = { workspace = true, features = ["from", "is_variant"] }
+
 [features]
 default = ["std"]
 std = ["bytes/std", "derive_more/std"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -142,7 +142,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -155,13 +155,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -222,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,18 +238,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -277,15 +274,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -306,15 +303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -322,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -334,14 +331,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -416,30 +413,11 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -496,7 +474,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -518,23 +496,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -545,7 +513,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -572,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -602,47 +570,47 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -665,16 +633,6 @@ dependencies = [
  "rustversion",
  "windows-link",
  "windows-result",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -764,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -774,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -808,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -987,7 +945,7 @@ checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -1044,7 +1002,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1063,16 +1021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1084,9 +1042,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1152,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -1179,9 +1137,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1209,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1306,7 +1264,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1326,7 +1284,7 @@ dependencies = [
  "spin",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
 ]
 
@@ -1383,18 +1341,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1413,9 +1371,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1482,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1513,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -1556,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -1594,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -1642,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-penguin"
@@ -1652,7 +1610,7 @@ version = "0.8.4"
 dependencies = [
  "arc-swap",
  "async-acceptor",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "clap",
  "derive_more",
@@ -1674,12 +1632,12 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki",
- "sha1 0.11.0",
+ "sha1",
  "socket2",
  "thiserror",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1695,7 +1653,7 @@ dependencies = [
  "rusty-penguin",
  "tempfile",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -1759,9 +1717,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1769,29 +1727,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1802,24 +1760,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1849,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -1877,9 +1824,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1887,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]
@@ -1914,9 +1861,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,7 +1889,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1949,22 +1907,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1975,18 +1933,18 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2004,9 +1962,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2024,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2041,13 +1999,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2069,18 +2027,31 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.30.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2110,7 +2081,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2165,12 +2136,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
+ "log",
+ "rand 0.9.5",
+ "thiserror",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
+ "rand 0.10.2",
+ "sha1",
  "thiserror",
 ]
 
@@ -2229,12 +2212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2442,28 +2419,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2483,7 +2460,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2523,11 +2500,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/penguin-mux/Cargo.toml
+++ b/penguin-mux/Cargo.toml
@@ -20,29 +20,29 @@ name = "penguin_mux"
 path = "src/lib.rs"
 
 [dependencies]
-bytes = { version = "^1, >=1.11.1", default-features = false }
+bytes = { workspace = true }
 cow-bytes = { path = "../cow-bytes", default-features = false }
-derive_more = { version = "2", features = ["debug", "deref", "from", "into"], default-features = false }
-futures-util = { version = "0.3", features = ["async-await-macro", "async-await"], default-features = false }
+derive_more = { workspace = true, features = ["debug", "deref", "from", "into"] }
+futures-util = { workspace = true, features = ["async-await-macro", "async-await"] }
 hashbrown = { version = "0.17", features = ["default-hasher"], default-features = false }
-nohash-hasher = { version = "0.2", default-features = false , optional = true }
-parking_lot = { version = "0.12", optional = true }
+nohash-hasher = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
 pin-project-lite = "0.2"
-rand = { version = "0.10", default-features = false }
+rand = { workspace = true }
 spin = { version = "0.12", features = ["use_ticket_mutex", "rwlock", "lock_api"], default-features = false }
-thiserror = { version = "2", default-features = false }
-tokio = { version = "^1, >=1.23.1", features = [ "sync"] }
-tokio-tungstenite = { version = "0.30", default-features = false, optional = true }
-tracing = { version = "0.1", features = ["attributes"], default-features = false }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "sync"] }
+tokio-tungstenite = { workspace = true, optional = true }
+tracing = { workspace = true }
 yawc = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 divan = "0.1"
-http-body-util = "0.1"
-hyper = { version = "1", features = ["server", "http1"] }
-hyper-util = { version = "0.1", features = ["server", "tokio"] }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["server", "http1"] }
+hyper-util = { workspace = true, features = ["server", "tokio"] }
 penguin-mux = { path = ".", default-features = false, features = ["__dev-dependencies"] }
-tracing-subscriber = { version = "^0.3, >=0.3.20", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint", "futures"] }

--- a/penguin-mux/Cargo.toml
+++ b/penguin-mux/Cargo.toml
@@ -66,5 +66,5 @@ deadlock-detection = ["std", "parking_lot/deadlock_detection"]
 
 __dev-dependencies = ["tokio-rt", "tokio/macros", "tokio/net", "tokio/rt-multi-thread"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)', 'cfg(loom)'] }
+[lints]
+workspace = true

--- a/penguin-socks/Cargo.toml
+++ b/penguin-socks/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["async", "socks", "socks4", "socks5"]
 categories = ["network-programming"]
 
 [dependencies]
-bytes = "^1, >=1.11.1"
-thiserror = "2"
-tokio = { version = "^1, >=1.23.1", features = ["io-util"] }
+bytes = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
 
 [dev-dependencies]
 penguin-socks = { path = ".", features = ["__dev-dependencies"] }

--- a/penguin/Cargo.toml
+++ b/penguin/Cargo.toml
@@ -124,8 +124,8 @@ tproxy = ["dep:socket2"]
 # Enable HTTP proxy remote support
 http-proxy = ["dep:http-body-util", "hyper/client", "dep:hyper-util"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dhat)', 'cfg(fuzzing)', 'cfg(loom)'] }
+[lints]
+workspace = true
 
 [package.metadata.deb]
 depends = "$auto"

--- a/penguin/Cargo.toml
+++ b/penguin/Cargo.toml
@@ -26,6 +26,7 @@ bytes = "^1, >=1.11.1"
 clap = { version = "4", features = ["cargo", "derive", "string"] }
 console-subscriber = { version = "0.5", features = ["parking_lot"], optional = true }
 derive_more = { version = "2", features = ["as_ref", "deref", "debug", "display", "from", "from_str"] }
+dn42-root-ca = { version = "1", optional = true }
 futures-util = { version = "0.3", default-features = false }
 http = "1"
 http-body-util = { version = "0.1", optional = true }
@@ -78,6 +79,7 @@ tls-native = ["dep:tokio-native-tls", "dep:hyper-tls"]
 # For rustls only: source of root certificates
 webpki-roots = ["dep:webpki-roots"]
 system-roots = ["dep:rustls-native-certs"]
+dn42-roots = ["dep:dn42-root-ca"]
 # Use ring or aws-lc-rs
 ring = ["instant-acme?/ring", "rcgen?/ring", "rustls/ring"]
 aws-lc-rs = ["instant-acme?/aws-lc-rs", "rcgen?/aws_lc_rs", "rustls/aws-lc-rs", "rustls/prefer-post-quantum", "rustls-webpki/aws-lc-rs"]

--- a/penguin/Cargo.toml
+++ b/penguin/Cargo.toml
@@ -67,16 +67,17 @@ rusty-penguin = { path = ".", default-features = false, features = ["__dev-depen
 dhat = { version = "0.3" }
 
 [features]
-default = ["rustls-native-roots", "tests-real-internet4", "tests-udp", "penguin-binary", "acme", "aws-lc-rs", "tproxy", "http-proxy"]
+default = ["tls-rustls", "system-roots", "tests-real-internet4", "tests-udp", "penguin-binary", "acme", "aws-lc-rs", "tproxy", "http-proxy"]
 
 ## TLS options
-# Note that it does not make sense to use more than one TLS implementations
+# Note that it does not make sense to use both TLS implementations
 # at the same time, but there must be at least one if `penguin-binary` is
 # enabled.
-rustls-webpki-roots = ["dep:webpki-roots", "__rustls"]
-rustls-native-roots = ["dep:rustls-native-certs", "__rustls"]
-__rustls = ["dep:rustls", "dep:rustls-pemfile", "dep:tokio-rustls", "dep:hyper-rustls"]
-nativetls = ["dep:tokio-native-tls", "dep:hyper-tls"]
+tls-rustls = ["dep:rustls", "dep:rustls-pemfile", "dep:tokio-rustls", "dep:hyper-rustls"]
+tls-native = ["dep:tokio-native-tls", "dep:hyper-tls"]
+# For rustls only: source of root certificates
+webpki-roots = ["dep:webpki-roots"]
+system-roots = ["dep:rustls-native-certs"]
 # Use ring or aws-lc-rs
 ring = ["instant-acme?/ring", "rcgen?/ring", "rustls/ring"]
 aws-lc-rs = ["instant-acme?/aws-lc-rs", "rcgen?/aws_lc_rs", "rustls/aws-lc-rs", "rustls/prefer-post-quantum", "rustls-webpki/aws-lc-rs"]

--- a/penguin/Cargo.toml
+++ b/penguin/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 arc-swap = "1"
 async-acceptor = { version = "0.1", path = "../async-acceptor", optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23", optional = true }
 bytes = "^1, >=1.11.1"
 clap = { version = "4", features = ["cargo", "derive", "string"] }
 console-subscriber = { version = "0.5", features = ["parking_lot"], optional = true }

--- a/penguin/Cargo.toml
+++ b/penguin/Cargo.toml
@@ -27,21 +27,21 @@ clap = { version = "4", features = ["cargo", "derive", "string"] }
 console-subscriber = { version = "0.5", features = ["parking_lot"], optional = true }
 derive_more = { version = "2", features = ["as_ref", "deref", "debug", "display", "from", "from_str"] }
 dn42-root-ca = { version = "1", optional = true }
-futures-util = { version = "0.3", default-features = false }
+futures-util = { workspace = true }
 http = "1"
-http-body-util = { version = "0.1", optional = true }
-hyper = { version = "1", features = ["server", "http1", "http2"], optional = true }
+http-body-util = { workspace = true, optional = true }
+hyper = { workspace = true, features = ["server", "http1", "http2"], optional = true }
 hyper-rustls = { version = "0.27", features = ["http1", "http2", "logging", "tls12"], default-features = false, optional = true }
 hyper-tls = { version = "0.6", features = ["alpn"], optional = true }
-hyper-util = { version = "0.1", features = ["client", "client-legacy", "server", "server-auto", "tokio"], optional = true }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "server", "server-auto", "tokio"], optional = true }
 idna = "1"
 instant-acme = { version = "0.8", features = ["rcgen", "hyper-rustls"], default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-nohash-hasher = { version = "0.2", optional = true }
-parking_lot = "0.12"
+nohash-hasher = { workspace = true, optional = true }
+parking_lot = { workspace = true }
 penguin-mux = { version = "0.8", path = "../penguin-mux", features = ["tungstenite"] }
 penguin-socks = { version = "0.1", path = "../penguin-socks", optional = true }
-rand = "0.10"
+rand = { workspace = true }
 rcgen = { version = "0.14", features = ["pem"], default-features = false, optional = true }
 rustls = { version = "^0.23, >=0.23.18", features = ["brotli", "logging", "std", "tls12"], default-features = false, optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
@@ -49,17 +49,16 @@ rustls-pemfile = { version = "2", optional = true }
 rustls-webpki = { version = "^0.103, >=0.103.13", optional = true }
 sha1 = { version = "0.11", optional = true }
 socket2 = { version = "0.6", features = ["all"], optional = true }
-thiserror = "2"
-tokio = { version = "^1, >=1.23.1", features = ["fs", "io-util", "macros", "net", "parking_lot", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "parking_lot", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-native-tls = { version = "0.3", optional = true }
 tokio-rustls = { version = "0.26", features = ["logging", "tls12"], default-features = false, optional = true }
-tokio-tungstenite = { version = "0.30", features = ["handshake"], default-features = false }
-tracing = "0.1"
-tracing-subscriber = "^0.3, >=0.3.20"
+tokio-tungstenite = { workspace = true, features = ["handshake"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 webpki-roots = { version = "1", optional = true }
 
 [dev-dependencies]
-divan = "0.1"
 tempfile = "3"
 # Hack; https://stackoverflow.com/q/73015087
 rusty-penguin = { path = ".", default-features = false, features = ["__dev-dependencies"] }

--- a/penguin/main.rs
+++ b/penguin/main.rs
@@ -104,12 +104,8 @@ async fn main() -> Result<(), Box<Error>> {
     Ok(())
 }
 
-#[cfg(all(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))]
-compile_error!("Only one of rustls-native-roots and rustls-webpki-roots can be enabled at a time");
-#[cfg(all(feature = "__rustls", feature = "nativetls"))]
-compile_error!(
-    "Only one of rustls-native-roots, rustls-webpki-roots, and nativetls can be enabled at a time"
-);
+#[cfg(all(feature = "tls-rustls", feature = "tls-native"))]
+compile_error!("tls-rustls and tls-native cannot both be enabled");
 #[cfg(all(feature = "tokio-console", feature = "remove-logging"))]
 compile_error!("tokio-console without trace-level logging is likely not desired");
 #[cfg(not(any(feature = "client", feature = "server")))]

--- a/penguin/src/arg/remote_spec.rs
+++ b/penguin/src/arg/remote_spec.rs
@@ -41,12 +41,12 @@ macro_rules! default_host {
 #[cfg(feature = "client")]
 pub(crate) use default_host;
 
-/// Default SOCKS port
+/// Default SOCKS port (IANA assigned)
 pub const SOCKS_DEFAULT_PORT: u16 = 1080;
 /// Default HTTP proxy port
 pub const HTTP_DEFAULT_PORT: u16 = 8080;
-/// Default TPROXY port
-pub const TPROXY_DEFAULT_PORT: u16 = 1234;
+/// Default TPROXY port (from debian netbase)
+pub const TPROXY_DEFAULT_PORT: u16 = 8081;
 
 macro_rules! add_brackets {
     ($host:expr) => {

--- a/penguin/src/server/acme/mod.rs
+++ b/penguin/src/server/acme/mod.rs
@@ -222,7 +222,7 @@ mod tests_need_pebble {
     #[derive(Clone, Debug)]
     pub struct IgnoreTlsHttpClient(HyperClient<HyperConnector, instant_acme::BodyWrapper<Bytes>>);
     impl IgnoreTlsHttpClient {
-        #[cfg(feature = "__rustls")]
+        #[cfg(feature = "tls-rustls")]
         pub async fn new() -> Self {
             // Not supposed to predefine ALPN protocols for ACME
             let client_config = make_client_config(None, None, None, true, None)
@@ -235,7 +235,7 @@ mod tests_need_pebble {
                 .build();
             Self(HyperClient::builder(TokioExecutor::new()).build(connector))
         }
-        #[cfg(feature = "nativetls")]
+        #[cfg(feature = "tls-native")]
         pub async fn new() -> Self {
             let client_config = make_client_config(None, None, None, true, None)
                 .await

--- a/penguin/src/server/mod.rs
+++ b/penguin/src/server/mod.rs
@@ -47,7 +47,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     /// Additional `native-tls` errors
     #[error("TLS error: {0}")]
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     NativeTls(#[from] tokio_native_tls::native_tls::Error),
     /// ACME client errors
     #[cfg(feature = "acme")]
@@ -236,9 +236,9 @@ pub async fn serve_connection_tls(
     tls_config: Arc<TlsIdentityInner>,
 ) {
     let tls_timeout = state.tls_timeout;
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     let stream_future = tokio_rustls::TlsAcceptor::from(tls_config).accept(stream);
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     let stream_future = tls_config.accept(stream);
 
     let stream = state.tls_timeout.timeout(stream_future).await;

--- a/penguin/src/server/service.rs
+++ b/penguin/src/server/service.rs
@@ -731,7 +731,14 @@ mod tests {
         server_task.abort();
     }
 
-    #[cfg(any(feature = "tests-real-internet4", feature = "tests-real-internet6"))]
+    #[cfg(all(
+        any(feature = "tests-real-internet4", feature = "tests-real-internet6"),
+        any(
+            feature = "tls-native",
+            feature = "system-roots",
+            feature = "webpki-roots"
+        ),
+    ))]
     #[tokio::test]
     async fn test_backend_tls() {
         use std::sync::LazyLock;

--- a/penguin/src/tests.rs
+++ b/penguin/src/tests.rs
@@ -9,7 +9,7 @@ use penguin_mux::timing::OptionalDuration;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{LazyLock, OnceLock};
 use std::{str::FromStr, time::Duration};
-#[cfg(not(all(feature = "nativetls", any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(all(feature = "tls-native", any(target_os = "macos", target_os = "windows"))))]
 use tempfile::TempDir;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
@@ -56,7 +56,7 @@ fn make_client_args(servhost: &str, servport: u16, remotes: Vec<Remote>) -> arg:
 
 /// Generate a self-signed server cert into a temporary directory.
 /// Returns the path to the directory. The cert is named `cert.pem` and the key is named `privkey.pem`.
-#[cfg(not(all(feature = "nativetls", any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(all(feature = "tls-native", any(target_os = "macos", target_os = "windows"))))]
 async fn make_server_cert_ecdsa(dest: Option<&str>) -> (Option<TempDir>, rcgen::Certificate) {
     let cert_params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
     let keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
@@ -436,7 +436,7 @@ async fn test_setting_outgoing_ip_works() {
 // `native_tls` on macOS and Windows doesn't support reading Ed25519 nor ECDSA-based certificates.
 #[tokio::test]
 #[cfg(all(feature = "client", feature = "server"))]
-#[cfg(not(all(feature = "nativetls", any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(all(feature = "tls-native", any(target_os = "macos", target_os = "windows"))))]
 async fn test_it_works_tls_simple() {
     static BACKEND_SUPPORTS_HTTP2: OnceLock<bool> = OnceLock::new();
     static SERVER_ARGS: OnceLock<arg::ServerArgs> = OnceLock::new();
@@ -508,7 +508,7 @@ async fn test_it_works_tls_simple() {
 #[tokio::test]
 #[cfg(unix)]
 #[cfg(feature = "server")]
-#[cfg(not(all(feature = "nativetls", any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(all(feature = "tls-native", any(target_os = "macos", target_os = "windows"))))]
 async fn test_tls_reload() {
     static BACKEND_SUPPORTS_HTTP2: OnceLock<bool> = OnceLock::new();
 
@@ -537,7 +537,7 @@ async fn test_tls_reload() {
     let stream = tls_connect(tcp_stream, "localhost", None, None, None, true)
         .await
         .unwrap();
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     {
         let peer_cert = stream
             .get_ref()
@@ -548,7 +548,7 @@ async fn test_tls_reload() {
             .unwrap();
         assert_eq!(peer_cert, **cert.der());
     }
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     {
         let (_, common_state) = stream.get_ref();
         let peer_cert = common_state.peer_certificates().unwrap();
@@ -577,7 +577,7 @@ async fn test_tls_reload() {
     let stream = tls_connect(tcp_stream, "localhost", None, None, None, true)
         .await
         .unwrap();
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     {
         let peer_cert = stream
             .get_ref()
@@ -588,7 +588,7 @@ async fn test_tls_reload() {
             .unwrap();
         assert_eq!(peer_cert, **new_cert.der());
     }
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     {
         let (_, common_state) = stream.get_ref();
         let peer_cert = common_state.peer_certificates().unwrap();
@@ -621,7 +621,7 @@ async fn check_http_host<T: AsyncRead + Unpin>(stream: &mut T, expected_host: &s
 // `native_tls` on macOS and Windows doesn't support reading Ed25519 nor ECDSA-based certificates.
 #[tokio::test]
 #[cfg(feature = "client")]
-#[cfg(not(all(feature = "nativetls", any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(all(feature = "tls-native", any(target_os = "macos", target_os = "windows"))))]
 async fn test_http_host_and_sni() {
     static CLIENT_ARGS_PLAIN: OnceLock<arg::ClientArgs> = OnceLock::new();
     static CLIENT_ARGS_HAS_HOSTNAME: OnceLock<arg::ClientArgs> = OnceLock::new();
@@ -642,9 +642,9 @@ async fn test_http_host_and_sni() {
         .await
         .unwrap()
         .load_full();
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     let acceptor = tokio_rustls::TlsAcceptor::from(tls_cfg);
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     let acceptor = tls_cfg;
 
     // The client will be in the task and the server will be the main task
@@ -714,7 +714,7 @@ async fn test_http_host_and_sni() {
     // First test: expect both Host to be the socket address and SNI to be unset
     let (stream, _) = listener.accept().await.unwrap();
     let mut tls_stream = acceptor.accept(stream).await.unwrap();
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     {
         let sni = tls_stream.get_ref().1.server_name().map(|s| s.to_string());
         assert!(sni.is_none());
@@ -725,7 +725,7 @@ async fn test_http_host_and_sni() {
     // Second test: expect Host and SNI to be "test-hostname"
     let (stream, _) = listener.accept().await.unwrap();
     let mut tls_stream = acceptor.accept(stream).await.unwrap();
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     {
         let sni = tls_stream.get_ref().1.server_name().map(|s| s.to_string());
         assert_eq!(sni, Some("test-hostname".to_string()));
@@ -735,7 +735,7 @@ async fn test_http_host_and_sni() {
     // Third test: expect Host to be "test-hostname" and SNI to be "test-sni"
     let (stream, _) = listener.accept().await.unwrap();
     let mut tls_stream = acceptor.accept(stream).await.unwrap();
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     {
         let sni = tls_stream.get_ref().1.server_name().map(|s| s.to_string());
         assert_eq!(sni, Some("test-sni".to_string()));

--- a/penguin/src/tls/maybe_tls.rs
+++ b/penguin/src/tls/maybe_tls.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// A stream that may be encrypted with TLS
 // This lint is a false positive because `T` is typically `TcpStream` which is not a zero-sized type.
-#[cfg_attr(feature = "__rustls", expect(clippy::large_enum_variant))]
+#[cfg_attr(feature = "tls-rustls", expect(clippy::large_enum_variant))]
 #[derive(Debug)]
 pub enum MaybeTlsStream<T> {
     /// A TLS-encrypted stream
@@ -61,21 +61,21 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<T> {
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 impl<S> From<tokio_rustls::server::TlsStream<S>> for MaybeTlsStream<S> {
     fn from(stream: tokio_rustls::server::TlsStream<S>) -> Self {
         Self::Tls(tokio_rustls::TlsStream::Server(stream))
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 impl<S> From<tokio_rustls::client::TlsStream<S>> for MaybeTlsStream<S> {
     fn from(stream: tokio_rustls::client::TlsStream<S>) -> Self {
         Self::Tls(tokio_rustls::TlsStream::Client(stream))
     }
 }
 
-#[cfg(feature = "nativetls")]
+#[cfg(feature = "tls-native")]
 impl<S> From<tokio_native_tls::TlsStream<S>> for MaybeTlsStream<S> {
     fn from(stream: tokio_native_tls::TlsStream<S>) -> Self {
         Self::Tls(stream)

--- a/penguin/src/tls/mod.rs
+++ b/penguin/src/tls/mod.rs
@@ -5,16 +5,16 @@
 #[cfg(feature = "aws-lc-rs")]
 pub mod aws_lc_rs_chromium;
 mod maybe_tls;
-#[cfg(feature = "nativetls")]
+#[cfg(feature = "tls-native")]
 mod native;
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 mod rustls;
 
-#[cfg(all(feature = "nativetls", feature = "acme"))]
+#[cfg(all(feature = "tls-native", feature = "acme"))]
 use self::native::make_server_config_from_pem;
-#[cfg(all(feature = "__rustls", feature = "acme"))]
+#[cfg(all(feature = "tls-rustls", feature = "acme"))]
 use self::rustls::make_server_config_from_pem;
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 use ::rustls::pki_types::InvalidDnsNameError;
 use arc_swap::ArcSwap;
 use std::sync::Arc;
@@ -22,19 +22,19 @@ use thiserror::Error;
 #[cfg(any(feature = "client", test))]
 use tokio::io::{AsyncRead, AsyncWrite};
 
-#[cfg(all(feature = "__rustls", feature = "server"))]
+#[cfg(all(feature = "tls-rustls", feature = "server"))]
 pub use self::rustls::{HyperConnector, make_hyper_connector};
 #[expect(clippy::module_name_repetitions)]
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 pub use self::rustls::{TlsIdentityInner, make_client_config, make_server_config};
-#[cfg(all(feature = "nativetls", feature = "server"))]
+#[cfg(all(feature = "tls-native", feature = "server"))]
 pub use native::{HyperConnector, make_hyper_connector};
-#[cfg(feature = "nativetls")]
+#[cfg(feature = "tls-native")]
 pub use native::{TlsIdentityInner, make_client_config, make_server_config};
 
-#[cfg(feature = "nativetls")]
+#[cfg(feature = "tls-native")]
 use tokio_native_tls::TlsStream;
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "tls-rustls")]
 use tokio_rustls::TlsStream;
 
 pub use maybe_tls::MaybeTlsStream;
@@ -54,19 +54,19 @@ pub enum Error {
     TcpConnect(std::io::Error),
     /// Errors from `rustls`
     #[error("rustls error: {0}")]
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     Rustls(#[from] ::rustls::Error),
     /// Could not determine the server name for SNI
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     #[error("unable to determine server name for SNI")]
     DnsName(#[from] InvalidDnsNameError),
     /// Could not create a TLS verifier for `rustls`
     #[error("verifier error: {0}")]
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     Verifier(#[from] ::rustls::client::VerifierBuilderError),
     /// Failed to parse certificates
     #[error("failed to parse certificates: {0}")]
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     CertParse(#[from] tokio_native_tls::native_tls::Error),
     /// Unsupported feature
     #[error("{0} is not supported: {1}")]
@@ -115,12 +115,12 @@ where
 {
     let config =
         make_client_config(tls_cert, tls_key, tls_ca, tls_insecure, Some(&["http/1.1"])).await?;
-    #[cfg(feature = "nativetls")]
+    #[cfg(feature = "tls-native")]
     let tls_stream = {
         let connector = tokio_native_tls::TlsConnector::from(config);
         connector.connect(server_name, underlying_io).await?
     };
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "tls-rustls")]
     let tls_stream = {
         let connector: tokio_rustls::TlsConnector = Arc::new(config).into();
         let server_name = ::rustls::pki_types::ServerName::try_from(server_name.to_string())?;

--- a/penguin/src/tls/rustls.rs
+++ b/penguin/src/tls/rustls.rs
@@ -142,7 +142,7 @@ async fn generate_rustls_rootcertstore(
         let (_, ignored) = roots.add_parsable_certificates(client_ca.map_err(Error::ReadCert)?);
         debug!("ignored {ignored} certificates from {ca_path}");
     } else {
-        #[cfg(feature = "rustls-native-roots")]
+        #[cfg(feature = "system-roots")]
         {
             let certerr = rustls_native_certs::load_native_certs();
             if !certerr.errors.is_empty() {
@@ -154,7 +154,7 @@ async fn generate_rustls_rootcertstore(
             let (_, ignored) = roots.add_parsable_certificates(certerr.certs);
             debug!("ignored {ignored} certificates from the system root");
         }
-        #[cfg(feature = "rustls-webpki-roots")]
+        #[cfg(feature = "webpki-roots")]
         roots.extend(webpki_roots::TLS_SERVER_ROOTS.to_vec());
     }
     Ok(roots)
@@ -264,6 +264,7 @@ mod tests {
         crate::tests::setup_logging();
         // No custom CA store
         let sys_root = generate_rustls_rootcertstore(None).await.unwrap();
+        #[cfg(any(feature = "system-roots", feature = "webpki-roots"))]
         assert!(!sys_root.is_empty());
         // Custom CA store
         let tmpdir = tempdir().unwrap();

--- a/penguin/src/tls/rustls.rs
+++ b/penguin/src/tls/rustls.rs
@@ -156,6 +156,8 @@ async fn generate_rustls_rootcertstore(
         }
         #[cfg(feature = "webpki-roots")]
         roots.extend(webpki_roots::TLS_SERVER_ROOTS.to_vec());
+        #[cfg(feature = "dn42-roots")]
+        roots.extend(dn42_root_ca::TLS_SERVER_ROOTS.to_vec());
     }
     Ok(roots)
 }


### PR DESCRIPTION
- Make default tproxy port 8081
- Reorganize tls root CA features
- Optionally use the dn42 root CA
- Use more workspace-level options